### PR TITLE
Added Network Mask option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Add the module to the modules array in the `config/config.js` file:
 | **Option** | **Default** | **Description** |
 | --- | --- | --- |
 | `devices` | [] | an array of device objects e.g. { macAddress: "aa:bb:cc:11:22:33", name: "DEVICE-NAME", icon: "FONT-AWESOME-ICON"} |
+| `network` | "" | Local Network IP mask, i.e. "192.168.0.0/24" |
 | `showUnknown` | true | shows devices found on the network even if not specified in the `devices` option |
 | `showOffline` | true | shows devices specified in the `devices` option even when offline |
 | `showLastSeen` | false | shows when the device was last seen e.g. "Device Name - last seen 5 minutes ago" |

--- a/node_helper.js
+++ b/node_helper.js
@@ -100,9 +100,7 @@ module.exports = NodeHelper.create({
             self.log("Checking Device...");
             if ("ipAddress" in device) {
                 self.log("pinging for ", device);
-                ping.sys.probe(device.ipAddress, function(isAlive,err) {
-                    self.log( isAlive );
-                    self.log( err );
+                ping.sys.probe(device.ipAddress, function(isAlive) {
                     device.online = isAlive;
                     if (isAlive) {
                         discoveredDevices.push(device);

--- a/node_helper.js
+++ b/node_helper.js
@@ -37,7 +37,11 @@ module.exports = NodeHelper.create({
         this.log(this.name + " is performing arp-scan");
 
         var self = this;
-        var arp = sudo(['arp-scan', '-l', '-q']);
+        if( self.config.network.length ){
+            var arp = sudo(['arp-scan', '-q', self.config.network]);
+        } else {
+            var arp = sudo(['arp-scan', '-l', '-q']);    
+        }        
         var buffer = '';
         var errstream = '';
         var discoveredMacAddresses = [];
@@ -93,9 +97,12 @@ module.exports = NodeHelper.create({
         var discoveredDevices = [];
         var self = this;
         this.config.devices.forEach( function(device) {
+            self.log("Checking Device...");
             if ("ipAddress" in device) {
                 self.log("pinging for ", device);
-                ping.sys.probe(device.ipAddress, function(isAlive) {
+                ping.sys.probe(device.ipAddress, function(isAlive,err) {
+                    self.log( isAlive );
+                    self.log( err );
                     device.online = isAlive;
                     if (isAlive) {
                         discoveredDevices.push(device);


### PR DESCRIPTION
Added a Network mask option that changes how the arp-scan is run. I was running into memory issues on a rPi3 with the default setup and this allows it to target the specific subnet without having to figure out the localnet.