### PR TITLE
Include MMM-Remote-Control req in sample conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Scan every 5 seconds and only display the specified devices whether they are onl
         }        
     },
 ````
+(Note that the 'MONITORON'/'MONITOROFF' actions require the MMM-Remote-Control module to be installed)
 
 ## Updating
 


### PR DESCRIPTION
The 'MONITORON'/'MONITOROFF' actions require the MMM-Remote-Control, but this is not mentioned in the readme.