### PR TITLE
Fix KeepAlive refresh

### DIFF
--- a/MMM-NetworkScanner.js
+++ b/MMM-NetworkScanner.js
@@ -84,7 +84,7 @@ Module.register("MMM-NetworkScanner", {
 
             if (this.config.showOffline) {
               var networkDevicesByMac = getKeyedObject(this.networkDevices, 'macAddress');
-              var payloadDevicesByMac = getKeyedObject(nextState, 'macAddress')
+              var payloadDevicesByMac = getKeyedObject(nextState, 'macAddress');
 
               nextState = this.config.devices.map(device => {
                 var oldDeviceState = networkDevicesByMac[device.macAddress];
@@ -96,7 +96,7 @@ Module.register("MMM-NetworkScanner", {
                   : null;
                 var isStale = (sinceLastSeen >= this.config.keepAlive);
 
-                newDeviceState.online = (sinceLastSeen != null) && (!isStale)
+                newDeviceState.online = (sinceLastSeen != null) && (!isStale);
 
                 return newDeviceState;
               });

--- a/MMM-NetworkScanner.js
+++ b/MMM-NetworkScanner.js
@@ -89,17 +89,14 @@ Module.register("MMM-NetworkScanner", {
               nextState = this.config.devices.map(device => {
                 var oldDeviceState = networkDevicesByMac[device.macAddress];
                 var payloadDeviceState = payloadDevicesByMac[device.macAddress];
-                var newDeviceState = payloadDeviceState
-                  ? payloadDeviceState
-                  : (oldDeviceState || device);
+                var newDeviceState = payloadDeviceState || oldDeviceState || device;
 
                 var sinceLastSeen = newDeviceState.lastSeen
                   ? moment().diff(newDeviceState.lastSeen, 'seconds')
                   : null;
+                var isStale = (sinceLastSeen >= this.config.keepAlive);
 
-                newDeviceState.online = (sinceLastSeen != null)
-                  ? (sinceLastSeen < this.config.keepAlive)
-                  : false;
+                newDeviceState.online = (sinceLastSeen != null) && (!isStale)
 
                 return newDeviceState;
               });


### PR DESCRIPTION
The state of every device was getting reset on every network refresh,
which is problematic when we want to display devices that weren't in the
refresh, but haven't passed their keepalive timeout.

This change determines if a device has gone past the timeout before
saving it to the devices to be displayed on the screen.

Fixes issue #14