### PR TITLE
Fix bug when both showOffline and showUnknown is enabled

### DIFF
--- a/MMM-NetworkScanner.js
+++ b/MMM-NetworkScanner.js
@@ -87,22 +87,26 @@ Module.register("MMM-NetworkScanner", {
 				var networkDevicesByMac = getKeyedObject(this.networkDevices, 'macAddress');
 				var payloadDevicesByMac = getKeyedObject(nextState, 'macAddress');
 
-				nextState = this.config.devices.map(device => {
-					if (device.macAddress) {
-						var oldDeviceState = networkDevicesByMac[device.macAddress];
-						var payloadDeviceState = payloadDevicesByMac[device.macAddress];
-						var newDeviceState = payloadDeviceState || oldDeviceState || device;
-
+				this.config.devices.forEach((d) => {
+					if(!nextState.find(v => v.macAddress === d.macAddress)){
+						nextState.push(d);
+					}
+				})
+				nextState = nextState.map(device => {
+					var definedDevice = this.config.devices.find(d => device.macAddress === d.macAddress)
+					if(!definedDevice){
+						return device;
+					}
+					if (definedDevice.macAddress) {
+						var oldDeviceState = networkDevicesByMac[definedDevice.macAddress];
+						var payloadDeviceState = payloadDevicesByMac[definedDevice.macAddress];
+						var newDeviceState = payloadDeviceState || oldDeviceState || definedDevice;
 						var sinceLastSeen = newDeviceState.lastSeen ?
 							moment().diff(newDeviceState.lastSeen, 'seconds') :
 							null;
 						var isStale = (sinceLastSeen >= this.config.keepAlive);
-
 						newDeviceState.online = (sinceLastSeen != null) && (!isStale);
-
 						return newDeviceState;
-					} else {
-						return device;
 					}
 				});
 			}


### PR DESCRIPTION
I have a lot of machines in the house aswell as airbnb-guests coming and going with devices so i want to keep track of who is in and not. With this module i was expecting that both `showOffline` and `showUnknown` works together to show offline mac-adresses aswell as unknown machines. 

So i noticed that it wasn't, so if i turned off showing offline units with `showOffline: false` then mac-adresses for unknowns were showing up. So i started digging and it turned out that the part that was setting the offline-status were only mapping through the configured devices. It saved only them when creating the new state if showOffline was enabled. The same behavior can still be enabled but by using `showUnknown: false` of course. 

Instead we now add the missing configured devices to the `nextState` and loop over that collection instead.This allows us to have both settings enabled at the same time as in the example below.

**Example with one machine `Cybercom` turned off and one machine unconfigured** 
![machines](https://user-images.githubusercontent.com/3242379/40392407-cca8f748-5e1b-11e8-9365-883152756155.png)



