### PR TITLE
New Feature: wildcards in mac-address

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -117,10 +117,16 @@ module.exports = NodeHelper.create({
 
     findDeviceByMacAddress: function (macAddress) {
         // Find first device with matching macAddress
+        var mac1 = macAddress.toUpperCase.split(":");
         for (var i = 0; i < this.config.devices.length; i++) {
             var device = this.config.devices[i];
             if (device.hasOwnProperty("macAddress")) {
-                if (macAddress.toUpperCase() === device.macAddress.toUpperCase()){
+                var mac2 = device.macAddress.toUpperCase.split(":");
+                var equal = true;
+                for (var j = 0; j < mac1.length; j++) {
+                  equal = equal && ( mac1[j] === mac2[j] || mac2[j] === "*" )
+                } 
+                if (equal) {
                     this.log(this.name + " found device by MAC Address", device);
                     return device;
                 }

--- a/node_helper.js
+++ b/node_helper.js
@@ -117,14 +117,14 @@ module.exports = NodeHelper.create({
 
     findDeviceByMacAddress: function (macAddress) {
         // Find first device with matching macAddress
-        var mac1 = macAddress.toUpperCase.split(":");
+        var mac1 = macAddress.toUpperCase().split(":");
         for (var i = 0; i < this.config.devices.length; i++) {
             var device = this.config.devices[i];
             if (device.hasOwnProperty("macAddress")) {
-                var mac2 = device.macAddress.toUpperCase.split(":");
+                var mac2 = device.macAddress.toUpperCase().split(":");
                 var equal = true;
                 for (var j = 0; j < mac1.length; j++) {
-                  equal = equal && ( mac1[j] === mac2[j] || mac2[j] === "*" )
+                  equal = equal && ((mac1[j] === mac2[j]) || (mac2[j] === "**"));
                 } 
                 if (equal) {
                     this.log(this.name + " found device by MAC Address", device);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "ping": "^0.1.10"
   },
   "devDependencies": {
-      "grunt": "latest",
-      "grunt-contrib-jshint": "latest",
-      "grunt-contrib-nodeunit": "latest"
+    "grunt": "latest",
+    "grunt-contrib-jshint": "latest",
+    "grunt-contrib-nodeunit": "latest"
   }
 }


### PR DESCRIPTION
You can use "**" at every 8-bit block in the mac-address to act as a wildcard.

I implemented this, because my range extenders are changing the mac addresses of devices to begin with the range extender one, and with wildcards I can have only one entry per device and still get info about it wherever it is located in the network.

If you look at this during October 2020, could you `hacktober-accept` it, pls?